### PR TITLE
Detailstable formatting changes

### DIFF
--- a/docs/objecttype/MegModeledEntityTag.mdx
+++ b/docs/objecttype/MegModeledEntityTag.mdx
@@ -36,9 +36,13 @@ sidebar_custom_props:
             <>
                 Returns whether the body clamp is uneven on the modeled entity.
                 Body clamp is used to clamp the body when the entity is standing still.
-
-                See also: <a href="#tag-megmodeledentitytagmax_body_angle"><code>MegModeledEntity.max_body_angle</code></a>
-                See also: <a href="#tag-megmodeledentitytagmin_body_angle"><code>MegModeledEntity.min_body_angle</code></a>
+            </>
+        }
+        See_Also={
+            <>
+                <a href="#tag-megmodeledentitytagmax_body_angle"><code>MegModeledEntity.max_body_angle</code></a>
+                <br />
+                <a href="#tag-megmodeledentitytagmin_body_angle"><code>MegModeledEntity.min_body_angle</code></a>
             </>
         }
     />

--- a/src/components/DetailsTable.module.css
+++ b/src/components/DetailsTable.module.css
@@ -1,3 +1,6 @@
 .entryRow {
     margin-bottom: 2rem;
 }
+.entryKey {
+    vertical-align: top;
+}

--- a/src/components/DetailsTable.module.css
+++ b/src/components/DetailsTable.module.css
@@ -1,0 +1,3 @@
+.entryRow {
+    margin-bottom: 2rem;
+}

--- a/src/components/DetailsTable.tsx
+++ b/src/components/DetailsTable.tsx
@@ -1,14 +1,19 @@
-
-
 import React from "react";
+import styles from "./DetailsTable.module.css";
 
 export function DetailsTable(details: Record<React.ReactNode, React.ReactNode>) {
     return (
         <div className="entryboxBody">
             <tbody>
                 {Object.entries(details).map(([key, value]) => (
-                    <tr key={key}>
-                        <td>{key}:</td>
+                    <tr key={key} className={styles.entryRow}>
+                        <td
+                            style={{
+                                verticalAlign: "top",
+                            }}
+                        >
+                            {key.replace(/\_/g, " ")}
+                        </td>
                         <td>{value}</td>
                     </tr>
                 ))}

--- a/src/components/DetailsTable.tsx
+++ b/src/components/DetailsTable.tsx
@@ -7,13 +7,7 @@ export function DetailsTable(details: Record<React.ReactNode, React.ReactNode>) 
             <tbody>
                 {Object.entries(details).map(([key, value]) => (
                     <tr key={key} className={styles.entryRow}>
-                        <td
-                            style={{
-                                verticalAlign: "top",
-                            }}
-                        >
-                            {key.replace(/\_/g, " ")}
-                        </td>
+                        <td className={styles.entryKey}>{key.replace(/\_/g, " ")}</td>
                         <td>{value}</td>
                     </tr>
                 ))}

--- a/src/components/ObjectType.tsx
+++ b/src/components/ObjectType.tsx
@@ -1,7 +1,7 @@
 import type { ObjectType } from "@site/src/types/objectType";
 import { urlObjectType } from "@site/src/utils/urls";
 
-export function ObjectType({ name, prefix, baseType, implementations, identityFormat, description }: ObjectType) {
+export function ObjectType({ name, prefix, baseType, implementations, identityFormat, description, seeAlso }: ObjectType) {
     return (
         <>
             <tbody>
@@ -35,6 +35,14 @@ export function ObjectType({ name, prefix, baseType, implementations, identityFo
                     <tr>
                         <td>Description:</td>
                         <td>{description}</td>
+                    </tr>
+                )}
+                {seeAlso && (
+                    <tr>
+                        <td>See also:</td>
+                        {seeAlso.map((seeAlso, index) => (
+                            <td key={index}>{seeAlso}</td>
+                        ))}
                     </tr>
                 )}
                 <tr>

--- a/src/types/objectType.ts
+++ b/src/types/objectType.ts
@@ -9,4 +9,5 @@ export type ObjectType = {
     implementations?: React.ReactNode[];
     identityFormat?: React.ReactNode;
     description?: React.ReactNode;
+    seeAlso: React.ReactNode[];
 };


### PR DESCRIPTION
## Changes

`DetailsTable` minor modifications:

- You can now use underscores in the prop key, which will be replaced with spaces. Example (from `MegModeledEntityTag.body_clamp_uneven`):

    ```tsx
        <DetailsTable
            See_Also={
                <>
                    <a href="#tag-megmodeledentitytagmax_body_angle"><code>MegModeledEntity.max_body_angle</code></a>
                    <br />
                    <a href="#tag-megmodeledentitytagmin_body_angle"><code>MegModeledEntity.min_body_angle</code></a>
                </>
            }
        />
    ```
- Keys in DetailsTable are now aligned to the top of the row.

    Before: 

    <img width="840" alt="Before image" src="https://github.com/user-attachments/assets/92c9134f-a324-4d5d-9f48-1c3bc8eec783" />

    After:
    
    <img width="884" alt="After image" src="https://github.com/user-attachments/assets/924a6184-9e01-412c-bd2f-7866fec7638d" />

- Rows in DetailsTable have a small margin between them.

The new "See Also" stuff should be written like this:

```tsx
        See_Also={
            <>
                <a href="#tag-megmodeledentitytagmax_body_angle"><code>MegModeledEntity.max_body_angle</code></a>
                <br />
                <a href="#tag-megmodeledentitytagmin_body_angle"><code>MegModeledEntity.min_body_angle</code></a>
            </>
        }
```

I have made this change for `MegModeledEntityTag.body_clamp_uneven`.
